### PR TITLE
feat: added jest-openapi to tests

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -80,7 +80,6 @@ components:
       required:
         - kind
         - isAlive
-        - description
       properties:
         kind:
           type: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -2524,6 +2524,35 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.6.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+          "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
+    },
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -3366,6 +3395,12 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "combos": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/combos/-/combos-0.2.0.tgz",
+      "integrity": "sha1-3DHFqJm0IpPVX+GcBk0+biB7pPc=",
+      "dev": true
     },
     "commitizen": {
       "version": "4.2.4",
@@ -8485,6 +8520,16 @@
         }
       }
     },
+    "jest-openapi": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/jest-openapi/-/jest-openapi-0.14.0.tgz",
+      "integrity": "sha512-W0lhviCPE0znqqkACwkl7+zG1ZT933YTPtnsThEeZJ8Ap6aTVsUao8vwSmXSwWVt/T3et1L+Zfww/UDJy8CD7A==",
+      "dev": true,
+      "requires": {
+        "jest-matcher-utils": "^26.6.2",
+        "openapi-validator": "^0.14.0"
+      }
+    },
     "jest-pnp-resolver": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
@@ -10175,6 +10220,119 @@
         "@jsdevtools/ono": "7.1.3"
       }
     },
+    "openapi-response-validator": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/openapi-response-validator/-/openapi-response-validator-9.3.0.tgz",
+      "integrity": "sha512-pklr94TIvl/ObZ0Gs04ihYWSi6w4k7jAerw1rSBHklb/ZbFTS5iP1t753PdSW9/7QJdXzZP/9uMADkhyURNjwA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.4.0",
+        "openapi-types": "^9.3.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.6.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+          "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
+    },
+    "openapi-schema-validator": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/openapi-schema-validator/-/openapi-schema-validator-9.3.0.tgz",
+      "integrity": "sha512-KlvgZMWTu+H1FHFSZNAGj369uXl3BD1nXSIq+sXlG6P+OrsAHd3YORx0ZEZ3WGdu2LQrPGmtowGQavYXL+PLwg==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.1.0",
+        "ajv-formats": "^2.0.2",
+        "lodash.merge": "^4.6.1",
+        "openapi-types": "^9.3.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.6.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+          "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
+    },
+    "openapi-types": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.0.tgz",
+      "integrity": "sha512-sR23YjmuwDSMsQVZDHbV9mPgi0RyniQlqR0AQxTC2/F3cpSjRFMH3CFPjoWvNqhC4OxPkDYNb2l8Mc1Me6D/KQ==",
+      "dev": true
+    },
+    "openapi-validator": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/openapi-validator/-/openapi-validator-0.14.0.tgz",
+      "integrity": "sha512-x9Vo0LSXNqnERvDvY7hRD3aGpJrWJFq3Llq2JiXZetW/H/wczuteTdKzCmxNERj1CdQWccsXNY2OAsXJVDI5qA==",
+      "dev": true,
+      "requires": {
+        "combos": "^0.2.0",
+        "fs-extra": "^9.0.0",
+        "js-yaml": "^4.0.0",
+        "openapi-response-validator": "^9.2.0",
+        "openapi-schema-validator": "^9.2.0",
+        "path-parser": "^6.1.0",
+        "typeof": "^1.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
+      }
+    },
     "opencollective-postinstall": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
@@ -10303,6 +10461,16 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "path-parser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/path-parser/-/path-parser-6.1.0.tgz",
+      "integrity": "sha512-nAB6J73z2rFcQP+870OHhpkHFj5kO4rPLc2Ol4Y3Ale7F6Hk1/cPKp7cQ8RznKF8FOSvu+YR9Xc6Gafk7DlpYA==",
+      "dev": true,
+      "requires": {
+        "search-params": "3.0.0",
+        "tslib": "^1.10.0"
+      }
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -10980,6 +11148,12 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
     "require-in-the-middle": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.1.0.tgz",
@@ -11182,6 +11356,12 @@
       "requires": {
         "xmlchars": "^2.2.0"
       }
+    },
+    "search-params": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/search-params/-/search-params-3.0.0.tgz",
+      "integrity": "sha512-8CYNl/bjkEhXWbDTU/K7c2jQtrnqEffIPyOLMqygW/7/b+ym8UtQumcAZjOfMLjZKR6AxK5tOr9fChbQZCzPqg==",
+      "dev": true
     },
     "semver": {
       "version": "7.3.2",
@@ -12487,6 +12667,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typeof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typeof/-/typeof-1.0.0.tgz",
+      "integrity": "sha1-nIRAPyMjrlOZFnJ1SXY46h0vJEA=",
+      "dev": true
     },
     "typescript": {
       "version": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "jest": "^26.6.3",
     "jest-create-mock-instance": "^1.1.0",
     "jest-html-reporters": "^2.0.3",
+    "jest-openapi": "^0.14.0",
     "js-yaml": "^4.1.0",
     "prettier": "^2.2.1",
     "pretty-quick": "^3.1.0",

--- a/tests/configurations/initJestOpenapi.setup.ts
+++ b/tests/configurations/initJestOpenapi.setup.ts
@@ -1,0 +1,4 @@
+import path from 'path';
+import jestOpenApi from 'jest-openapi';
+
+jestOpenApi(path.join(process.cwd(), 'openapi3.yaml'));

--- a/tests/configurations/integration/jest.config.js
+++ b/tests/configurations/integration/jest.config.js
@@ -2,13 +2,19 @@ module.exports = {
   transform: {
     '^.+\\.ts$': 'ts-jest',
   },
+  globals: {
+    'ts-jest': {
+      tsConfig: 'tsconfig.test.json'
+    }
+  },
   coverageReporters: ['text', 'html'],
   collectCoverage: true,
   collectCoverageFrom: ['<rootDir>/src/**/*.ts', '!*/node_modules/', '!/vendor/**', '!*/common/**', '!**/models/**', '!<rootDir>/src/*'],
   coverageDirectory: '<rootDir>/coverage',
   rootDir: '../../../.',
   testMatch: ['<rootDir>/tests/integration/**/*.spec.ts'],
-  setupFiles: ['<rootDir>/tests/configurations/jest.setup.js'],
+  setupFiles: ['<rootDir>/tests/configurations/jest.setup.ts'],
+  setupFilesAfterEnv: ['jest-openapi', '<rootDir>/tests/configurations/initJestOpenapi.setup.ts'],
   reporters: [
     'default',
     [

--- a/tests/configurations/jest.setup.js
+++ b/tests/configurations/jest.setup.js
@@ -1,1 +1,0 @@
-require('reflect-metadata');

--- a/tests/configurations/jest.setup.ts
+++ b/tests/configurations/jest.setup.ts
@@ -1,0 +1,1 @@
+import 'reflect-metadata';

--- a/tests/configurations/unit/jest.config.js
+++ b/tests/configurations/unit/jest.config.js
@@ -2,6 +2,11 @@ module.exports = {
   transform: {
     '^.+\\.ts$': 'ts-jest',
   },
+  globals: {
+    'ts-jest': {
+      tsConfig: 'tsconfig.test.json'
+    }
+  },
   testMatch: ['<rootDir>/tests/unit/**/*.spec.ts'],
   coverageReporters: ['text', 'html'],
   collectCoverage: true,
@@ -20,7 +25,7 @@ module.exports = {
     ['jest-html-reporters', { multipleReportsUnitePath: './reports', pageTitle: 'unit', publicPath: './reports', filename: 'unit.html' }],
   ],
   rootDir: '../../../.',
-  setupFiles: ['<rootDir>/tests/configurations/jest.setup.js'],
+  setupFiles: ['<rootDir>/tests/configurations/jest.setup.ts'],
   preset: 'ts-jest',
   testEnvironment: 'node',
   coverageThreshold: {

--- a/tests/integration/anotherResource/anotherResourceName.spec.ts
+++ b/tests/integration/anotherResource/anotherResourceName.spec.ts
@@ -24,6 +24,7 @@ describe('resourceName', function () {
       const response = await requestSender.getResource();
 
       expect(response.status).toBe(httpStatusCodes.OK);
+      expect(response).toSatisfyApiSpec();
 
       const resource = response.body as IAnotherResourceModel;
       expect(resource.kind).toEqual('avi');

--- a/tests/integration/resourceName/resourceName.spec.ts
+++ b/tests/integration/resourceName/resourceName.spec.ts
@@ -1,6 +1,7 @@
 import jsLogger from '@map-colonies/js-logger';
 import { trace } from '@opentelemetry/api';
 import httpStatusCodes from 'http-status-codes';
+
 import { getApp } from '../../../src/app';
 import { SERVICES } from '../../../src/common/constants';
 import { IResourceNameModel } from '../../../src/resourceName/models/resourceNameManager';
@@ -26,6 +27,7 @@ describe('resourceName', function () {
       expect(response.status).toBe(httpStatusCodes.OK);
 
       const resource = response.body as IResourceNameModel;
+      expect(response).toSatisfyApiSpec();
       expect(resource.id).toEqual(1);
       expect(resource.name).toEqual('ronin');
       expect(resource.description).toEqual('can you do a logistics run?');

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": true
+  },
+
+  "include": ["src", "tests"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✔                                                                       |

Further  information:
<!--
Here you can provide more information regarding any of the questions written above.
In addition, you can add screenshots, ask the maintainers questions.
-->
The jest-openapi package can accept openapi spec as an input and validates responses based on the schema specified in the spec, it is very useful to use this package for integrations tests, you can read more [here](https://github.com/openapi-library/OpenAPIValidators/tree/master/packages/jest-openapi) 