### PR TITLE
feat: install git hooks after npm install command

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "build": "tsc --project tsconfig.build.json  && npm run assets:copy",
     "start": "npm run build && cd dist && node ./index.js",
     "assets:copy": "copyfiles -f ./config/* ./dist/config && copyfiles -f ./openapi3.yaml ./dist/ && copyfiles ./package.json dist",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist",
+    "install": "npx husky install"
   },
   "directories": {
     "test": "tests"


### PR DESCRIPTION


| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change |   ✖                                                                       |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Related issues: #XXX , #XXX ...
Husky has removed its post-install scripts, which means the user must manually run `npx husky install` -> most developers forget to do that, so I added a post-install script for the project to install the git hooks.
