### PR TITLE
fix: terminus options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ void getApp()
     const port = config.get('server.port');
     const stubHealthCheck = async (): Promise<void> => Promise.resolve();
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    const server = createTerminus(createServer(app), { healthChecks: { '/liveness': stubHealthCheck, onSignal: container.resolve('onSignal') } });
+    const server = createTerminus(createServer(app), { healthChecks: { '/liveness': stubHealthCheck }, onSignal: container.resolve('onSignal') });
 
     server.listen(port, () => {
       logger.info(`app started on port ${port}`);


### PR DESCRIPTION
`onSignal` was incorrectly set in `healthChecks`

| Question        | Answer |
| --------------- | ------ |
| Bug fix         | ✔  |
| New feature     | ✖  |
| Breaking change | ✖  |
| Deprecations    | ✖  |
| Documentation   | ✖  |
| Tests added     | ✖  |
| Chore           | ✖  |

Closes #318