### PR TITLE
feat: update schema version

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -6,6 +6,7 @@
     "uiPath": "/api"
   },
   "telemetry": {
+    "metrics": {},
     "tracing": {
       "isEnabled": false
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@map-colonies/js-logger": "^1.0.1",
         "@map-colonies/openapi-express-viewer": "^3.0.0",
         "@map-colonies/read-pkg": "0.0.1",
-        "@map-colonies/schemas": "^1.0.1",
+        "@map-colonies/schemas": "^1.3.0",
         "@map-colonies/telemetry": "^7.0.1",
         "@opentelemetry/api": "^1.7.0",
         "compression": "^1.7.4",
@@ -1975,6 +1975,7 @@
       "version": "7.25.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
       "integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -2000,6 +2001,7 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/template": {
@@ -4148,13 +4150,10 @@
       }
     },
     "node_modules/@map-colonies/schemas": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@map-colonies/schemas/-/schemas-1.0.1.tgz",
-      "integrity": "sha512-240Hd48pkPhP1Jk033p4mSxT0OgeQNPDn7QJV51mZAhDPptJUse42VEt2geLt4MeYgfOyxmJEVEdmNFG34ODRw==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.0.1"
-      }
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/schemas/-/schemas-1.3.0.tgz",
+      "integrity": "sha512-c7dllL2LD69JThb2ddKFvY/Q2lJHHpmO9Rt/rzwdeR4KMZ9VfHEpJnsr3o0/vR6PTIIWU10V/X7rU/FxWrBx/g==",
+      "license": "MIT"
     },
     "node_modules/@map-colonies/telemetry": {
       "version": "7.0.1",
@@ -13734,18 +13733,6 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -16779,11 +16766,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="
     },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@map-colonies/js-logger": "^1.0.1",
     "@map-colonies/openapi-express-viewer": "^3.0.0",
     "@map-colonies/read-pkg": "0.0.1",
-    "@map-colonies/schemas": "^1.0.1",
+    "@map-colonies/schemas": "^1.3.0",
     "@map-colonies/telemetry": "^7.0.1",
     "@opentelemetry/api": "^1.7.0",
     "compression": "^1.7.4",

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -1,8 +1,8 @@
 import { type ConfigInstance, config } from '@map-colonies/config';
-import { commonBoilerplateV1, type commonBoilerplateV1Type } from '@map-colonies/schemas';
+import { commonBoilerplateV2, type commonBoilerplateV2Type } from '@map-colonies/schemas';
 
 // Choose here the type of the config instance and import this type from the entire application
-type ConfigType = ConfigInstance<commonBoilerplateV1Type>;
+type ConfigType = ConfigInstance<commonBoilerplateV2Type>;
 
 let configInstance: ConfigType | undefined;
 
@@ -13,8 +13,8 @@ let configInstance: ConfigType | undefined;
  */
 async function initConfig(offlineMode?: boolean): Promise<void> {
   configInstance = await config({
-    schema: commonBoilerplateV1,
-    offlineMode: offlineMode,
+    schema: commonBoilerplateV2,
+    offlineMode,
   });
 }
 


### PR DESCRIPTION
This pull request includes updates to configuration files and dependencies, as well as changes to the schema type used in the project. The most important changes include updating the telemetry configuration, upgrading the `@map-colonies/schemas` package, and modifying the configuration schema type in the codebase.

Configuration updates:

* [`config/default.json`](diffhunk://#diff-f07c42814e0913799fda32ac14d063f1ef8a04e24fb6febd873a5f161e58a8d4R9): Added an empty `metrics` object to the telemetry configuration.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L39-R39): Upgraded the `@map-colonies/schemas` package from version `^1.0.1` to `^1.3.0`.

Schema type updates:

* [`src/common/config.ts`](diffhunk://#diff-9d5ba1a74fa3c1ca2e89c9b7a2c356807802c8b5be7473377ffd4d9ab348aef1L2-R5): Changed the import and type definition from `commonBoilerplateV1` to `commonBoilerplateV2` for the configuration schema.
* [`src/common/config.ts`](diffhunk://#diff-9d5ba1a74fa3c1ca2e89c9b7a2c356807802c8b5be7473377ffd4d9ab348aef1L16-R17): Updated the `initConfig` function to use `commonBoilerplateV2` for the schema.