### PR TITLE
refactor: change container source to be from an import to getApp returned value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,13 +3,12 @@ import 'reflect-metadata';
 import { createServer } from 'http';
 import { createTerminus } from '@godaddy/terminus';
 import { Logger } from '@map-colonies/js-logger';
-import { container } from 'tsyringe';
 import { SERVICES } from '@common/constants';
 import { ConfigType } from '@common/config';
 import { getApp } from './app';
 
 void getApp()
-  .then(([app]) => {
+  .then(([app, container]) => {
     const logger = container.resolve<Logger>(SERVICES.LOGGER);
     const config = container.resolve<ConfigType>(SERVICES.CONFIG);
     const port = config.get('server.port');


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question        | Answer |
| --------------- | ------ |
| Bug fix         | ✖  |
| New feature     | ✖  |
| Breaking change | ✖  |
| Deprecations    | ✖  |
| Documentation   | ✖  |
| Tests added     | ✖  |
| Chore           | ✖  |

Further information:
I think instead of importing container from `tsyringe` we should use the created and returned container from getApp returned value. What do you think? 