### PR TITLE
ci: fix-docker-release-tag

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   build_and_push_docker:
-    uses: MapColonies/shared-workflows/.github/workflows/build-and-push-docker.yaml@v2
+    uses: MapColonies/shared-workflows/.github/workflows/build-and-push-docker.yaml@v4
     secrets: inherit
     with:
       # for example
@@ -27,7 +27,7 @@ jobs:
       scope: YOUR-DOMAIN
 
   build_and_push_helm:
-    uses: MapColonies/shared-workflows/.github/workflows/build-and-push-helm.yaml@v2
+    uses: MapColonies/shared-workflows/.github/workflows/build-and-push-helm.yaml@v4
     secrets: inherit
     with:
       # for example


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question        | Answer |
| --------------- | ------ |
| Bug fix         | ✖  |
| New feature     | ✖  |
| Breaking change | ✖  |
| Deprecations    | ✖  |
| Documentation   | ✖  |
| Tests added     | ✖  |
| Chore           | ✖  |

Further information:
I've noticed that our built docker image was pushed without the domain prefix. 
This commit should fix this for all. 