### PR TITLE
chore: remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*  @netanelC @CptSchnitz @shimoncohen


### PR DESCRIPTION
This PR removes the CODEOWNERS file as it appears everytime the developers create a new repo based on this boilerplate.
The code owners will be forced from the settings of the repo

| Question        | Answer |
| --------------- | ------ |
| Bug fix         | ✖  |
| New feature     | ✖  |
| Breaking change | ✖  |
| Deprecations    | ✖  |
| Documentation   | ✖  |
| Tests added     | ✖  |
| Chore           | ✔  |