### PR TITLE
devdeps: update commitlint configuration and dependencies

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,3 @@
 module.exports = {
-  extends: ['@commitlint/config-conventional'],
-  rules: {
-    'scope-enum': [2, 'always', ['deps', 'configurations']],
-  },
+  extends: ['@map-colonies/commitlint-config'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
       },
       "devDependencies": {
         "@commitlint/cli": "^19.5.0",
-        "@commitlint/config-conventional": "^19.5.0",
         "@map-colonies/commitlint-config": "^1.1.1",
         "@map-colonies/eslint-config": "^4.0.0",
         "@map-colonies/openapi-helpers": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
       "devDependencies": {
         "@commitlint/cli": "^19.5.0",
         "@commitlint/config-conventional": "^19.5.0",
+        "@map-colonies/commitlint-config": "^1.1.1",
         "@map-colonies/eslint-config": "^4.0.0",
         "@map-colonies/openapi-helpers": "^1.2.0",
         "@map-colonies/prettier-config": "0.0.1",
@@ -2078,12 +2079,13 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.5.0.tgz",
-      "integrity": "sha512-OBhdtJyHNPryZKg0fFpZNOBM1ZDbntMvqMuSmpfyP86XSfwzGw4CaoYRG4RutUPg0BTK07VMRIkNJT6wi2zthg==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.8.0.tgz",
+      "integrity": "sha512-9I2kKJwcAPwMoAj38hwqFXG0CzS2Kj+SAByPUQ0SlHTfb7VUhYVmo7G2w2tBrqmOf7PFd6MpZ/a1GQJo8na8kw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/types": "^19.8.0",
         "conventional-changelog-conventionalcommits": "^7.0.2"
       },
       "engines": {
@@ -2584,10 +2586,11 @@
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.5.0.tgz",
-      "integrity": "sha512-DSHae2obMSMkAtTBSOulg5X7/z+rGLxcXQIkg3OmWvY6wifojge5uVMydfhUvs7yQj+V7jNmRZ2Xzl8GJyqRgg==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.8.0.tgz",
+      "integrity": "sha512-LRjP623jPyf3Poyfb0ohMj8I3ORyBDOwXAgxxVPbSD0unJuW2mJWeiRfaQinjtccMqC5Wy1HOMfa4btKjbNxbg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/conventional-commits-parser": "^5.0.0",
         "chalk": "^5.3.0"
@@ -3757,6 +3760,19 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+    },
+    "node_modules/@map-colonies/commitlint-config": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@map-colonies/commitlint-config/-/commitlint-config-1.1.1.tgz",
+      "integrity": "sha512-CzGXbec9SwpGGngZddUJ7rfZiJeUNUxLjWir1GRACjOYO19EliXF9MwVn4rOtscKQCmuaTEMOg4+21LyFdqRyg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@commitlint/config-conventional": "^19.6.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@map-colonies/config": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^19.5.0",
-    "@commitlint/config-conventional": "^19.5.0",
     "@map-colonies/eslint-config": "^4.0.0",
     "@map-colonies/openapi-helpers": "^1.2.0",
     "@map-colonies/prettier-config": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@map-colonies/eslint-config": "^4.0.0",
     "@map-colonies/openapi-helpers": "^1.2.0",
     "@map-colonies/prettier-config": "0.0.1",
+    "@map-colonies/commitlint-config": "^1.1.1",
     "@redocly/openapi-cli": "^1.0.0-beta.94",
     "@swc/core": "^1.7.26",
     "@swc/jest": "^0.2.36",


### PR DESCRIPTION
This pull request includes changes to the configuration files to standardize the linting rules and update dependencies.

Configuration updates:

* [`commitlint.config.js`](diffhunk://#diff-2b1ae4316086c0ebb213227790133a792300e1cef03b0afc067b23d3399ea5caL2-R2): Updated the commit linting configuration to use `@map-colonies/commitlint-config` instead of `@commitlint/config-conventional`.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R56): Added `@map-colonies/commitlint-config` version `^1.1.1` to the list of dependencies.