### PR TITLE
build: update Node.js Docker base image to node:20.19.0-alpine3.21 for production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN npm install
 COPY . .
 RUN npm run build
 
-FROM node:20.3.1-alpine3.17 as production
+FROM node:20.19.0-alpine3.21 as production
 
 RUN apk add dumb-init
 


### PR DESCRIPTION
To accommodate the @map-colonies/config package (version 2.0.0), which mandates Node.js version 20.18 or higher, this PR upgrades the production Docker image to node:20.19.0-alpine3.21. The Dockerfile has been modified to ensure compatibility