### PR TITLE
feat: enhance ingress configuration with dynamic service name and port MAPCO-10571

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,34 +1,77 @@
-{{- $releaseName := .Release.Name -}}
-{{- $chartName := include "ts-server-boilerplate.name" . -}}
 {{- if and (.Values.enabled) (.Values.ingress.enabled) -}}
+{{- $fullName := include "ts-server-boilerplate.fullname" . -}}
+{{- $serviceName := $fullName -}}
+{{- $servicePort := .Values.env.port -}}
+{{- $ingressPath := default "/" .Values.ingress.path -}}
+{{- $ingressPathType := default "Prefix" .Values.ingress.pathType -}}
+{{- $extraPaths := .Values.ingress.extraPaths -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "ts-server-boilerplate.fullname" . }}
-  annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.org/mergeable-ingress-type: "minion"
-    nginx.org/rewrites: 'serviceName={{ include "ts-server-boilerplate.fullname" . }} rewrite=/'    
-    nginx.org/location-snippets: |
-      if ($request_method = OPTIONS) {
-        return 204;
-      }
-    {{- if .Values.ingress.cors.enabled }}
-      add_header 'Access-Control-Allow-Origin' '{{- .Values.ingress.cors.origin -}}';
-      add_header 'Access-Control-Max-Age' 3600;
-      add_header 'Access-Control-Expose-Headers' 'Content-Length';
-      add_header 'Access-Control-Allow-Headers' '*';
+  name: {{ $fullName }}-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ts-server-boilerplate.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ tpl ($value | toString) $ | quote }}
+    {{- end }}
+  {{- end }}
 spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
   rules:
-  - http:
-      paths:
-      - path: {{ .Values.ingress.path }}
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ include "ts-server-boilerplate.fullname" . }}
-            port:
-              number: {{ .Values.env.port }}
-    host: {{ .Values.ingress.host | quote }}
-{{- end -}}
+  {{- if .Values.ingress.hosts }}
+  {{- range .Values.ingress.hosts }}
+    - host: {{ tpl . $ | quote }}
+      http:
+        paths:
+          {{- with $extraPaths }}
+          {{- tpl (toYaml .) $ | nindent 10 }}
+          {{- end }}
+          - path: {{ $ingressPath }}
+            pathType: {{ $ingressPathType }}
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+  {{- end }}
+  {{- else if .Values.ingress.host }}
+    - host: {{ tpl .Values.ingress.host $ | quote }}
+      http:
+        paths:
+          {{- with $extraPaths }}
+          {{- tpl (toYaml .) $ | nindent 10 }}
+          {{- end }}
+          - path: {{ $ingressPath }}
+            pathType: {{ $ingressPathType }}
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+  {{- else }}
+    - http:
+        paths:
+          {{- with $extraPaths }}
+          {{- tpl (toYaml .) $ | nindent 10 }}
+          {{- end }}
+          - path: {{ $ingressPath }}
+            pathType: {{ $ingressPathType }}
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+  {{- end -}}
+{{- end }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "ts-server-boilerplate.fullname" . -}}
 {{- $serviceName := $fullName -}}
 {{- $servicePort := .Values.env.port -}}
-{{- $ingressPath := default "/" .Values.ingress.path -}}
+{{- $ingressPath := .Values.ingress.path -}}
 {{- $ingressPathType := default "Prefix" .Values.ingress.pathType -}}
 {{- $extraPaths := .Values.ingress.extraPaths -}}
 apiVersion: networking.k8s.io/v1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -113,8 +113,18 @@ route:
 
 ingress:
   enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  labels: {}
   path: /
+  pathType: Prefix
+  extraPaths: []
+  hosts: []
+  #  - "chart-example.local"
   host: 'localhost'
-  cors:
-    enabled: true
-    origin: '*'
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question        | Answer |
| --------------- | ------ |
| Bug fix         | ✔/✖    |
| New feature     | ✔/✖    |
| Breaking change | ✔/✖    |
| Deprecations    | ✔/✖    |
This pull request significantly refactors the Helm ingress template to improve flexibility and maintainability. The changes introduce better templating for dynamic values, support for multiple hosts, TLS, custom annotations, and extra paths, making the ingress configuration more robust and customizable.

Key improvements to the Helm ingress template:

**Enhanced templating and dynamic values:**
* Replaces hardcoded and duplicated values with variables like `$fullName`, `$serviceName`, `$servicePort`, `$ingressPath`, and `$ingressPathType` for easier maintenance and consistency throughout the template.

**Ingress configuration flexibility:**
* Adds support for specifying multiple hosts and extra paths, allowing more complex ingress routing scenarios.
* Adds conditional inclusion of `ingressClassName` and TLS configuration, making the ingress resource compatible with a wider range of Kubernetes environments.

**Improved annotations and labels handling:**
* Refactors annotations and labels to use Helm's templating and YAML utilities, allowing for dynamic, user-supplied values from `values.yaml`.

**Namespace and naming improvements:**
* Sets the ingress resource name to include `-ingress` and explicitly sets the namespace, improving resource clarity and scoping.
| Documentation   | ✔/✖    |
| Tests added     | ✔/✖    |
| Chore           | ✔/✖    |

Related issues: #XXX , #XXX ...
Closes #XXX ...

Further information:

<!--
Here you can provide more information regarding any of the questions written above.
In addition, you can add screenshots, ask the maintainers questions.
-->
